### PR TITLE
New Feature: Hover Track Cards

### DIFF
--- a/src/components/track.tsx
+++ b/src/components/track.tsx
@@ -16,7 +16,7 @@ const TitleContainer = styled.div`
 
   border-radius: 5px;
   color: white;
-  background-color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(0, 0, 0, 0.9);
 
   -webkit-backdrop-filter: blur(10px);
 
@@ -45,8 +45,8 @@ const ImageContainer = styled.div`
 const Title = styled.div`
   color: white;
 
-  padding-top: 1rem;
-  padding-left: 1rem;
+  padding: 1rem;
+  padding-bottom: 0;
 
   font-size: 1.25rem;
   font-weight: bold;

--- a/src/components/track.tsx
+++ b/src/components/track.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import * as React from "react";
-import { accentColor } from "../constants";
+import { accentColor, transitionDuration } from "../constants";
 import { usePublicFileURL } from "../hooks/use-public-file-url";
 
 const TitleContainer = styled.div`
@@ -11,13 +11,14 @@ const TitleContainer = styled.div`
   right: 0;
   height: 4.5rem;
   overflow: hidden;
-  transition: 0.5s ease;
+  transition-property: height;
+  transition-duration: ${transitionDuration};
 
+  border-radius: 5px;
+  color: white;
   background-color: rgba(0, 0, 0, 0.75);
 
   -webkit-backdrop-filter: blur(10px);
-  border-top-right-radius: 3px;
-  border-bottom-right-radius: 3px;
 
   z-index: 0;
   cursor: default;
@@ -35,7 +36,6 @@ const ImageContainer = styled.div`
 
   background-size: 100% auto;
   background-color: white;
-  background-position: center center;
 
   &:hover ${TitleContainer} {
     height: 100%;
@@ -50,25 +50,16 @@ const Title = styled.div`
 
   font-size: 1.25rem;
   font-weight: bold;
-  text-align: left;
   text-transform: uppercase;
 `;
 
 const Description = styled.div`
   display: block;
 
-  color: white;
-
-  padding-top: 1rem;
-  padding-left: 1rem;
+  padding: 1rem;
 
   font-size: 0.8rem;
   text-align: left;
-
-  &::before {
-    opacity: 0.9;
-    color: white;
-  }
 `;
 
 const Sponsor = styled.div`

--- a/src/components/track.tsx
+++ b/src/components/track.tsx
@@ -4,14 +4,14 @@ import { accentColor } from "../constants";
 import { usePublicFileURL } from "../hooks/use-public-file-url";
 
 const TitleContainer = styled.div`
-  overflow: hidden;
-  height: 4.5rem;
-  transition: 0.5s;
-
   position: absolute;
+
   bottom: 0;
   left: 0;
   right: 0;
+  height: 4.5rem;
+  overflow: hidden;
+  transition: 0.5s ease;
 
   background-color: rgba(0, 0, 0, 0.75);
 
@@ -34,8 +34,8 @@ const ImageContainer = styled.div`
   border-radius: 5px;
 
   background-size: 100% auto;
-  background-position: center center;
   background-color: white;
+  background-position: center center;
 
   &:hover ${TitleContainer} {
     height: 100%;
@@ -44,8 +44,10 @@ const ImageContainer = styled.div`
 
 const Title = styled.div`
   color: white;
-  padding-left: 1rem;
+
   padding-top: 1rem;
+  padding-left: 1rem;
+
   font-size: 1.25rem;
   font-weight: bold;
   text-align: left;
@@ -56,8 +58,10 @@ const Description = styled.div`
   display: block;
 
   color: white;
+
   padding-top: 1rem;
   padding-left: 1rem;
+
   font-size: 0.8rem;
   text-align: left;
 
@@ -69,9 +73,11 @@ const Description = styled.div`
 
 const Sponsor = styled.div`
   display: block;
-  padding-left: 1rem;
 
   color: ${accentColor};
+
+  padding-left: 1rem;
+
   font-size: 0.8rem;
   text-align: left;
   text-transform: uppercase;

--- a/src/components/track.tsx
+++ b/src/components/track.tsx
@@ -3,11 +3,30 @@ import * as React from "react";
 import { accentColor } from "../constants";
 import { usePublicFileURL } from "../hooks/use-public-file-url";
 
+const TitleContainer = styled.div`
+  overflow: hidden;
+  height: 4.5rem;
+  transition: 0.5s;
+
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+
+  background-color: rgba(0, 0, 0, 0.75);
+
+  -webkit-backdrop-filter: blur(10px);
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+
+  z-index: 0;
+  cursor: default;
+`;
+
 const ImageContainer = styled.div`
   position: relative;
 
   display: block;
-  width: 100%;
   height: 15rem;
   overflow: hidden;
   margin-bottom: 1rem;
@@ -17,35 +36,45 @@ const ImageContainer = styled.div`
   background-size: 100% auto;
   background-position: center center;
   background-color: white;
+
+  &:hover ${TitleContainer} {
+    height: 100%;
+  }
 `;
 
-const Title = styled.h3`
-  position: absolute;
-  bottom: 1rem;
-  left: 0rem;
-
-  padding: 1rem 1.5rem;
-
-  font-size: 1.25rem;
-  text-align: center;
-  text-transform: uppercase;
-
-  background-color: rgba(0, 0, 0, 0.75);
+const Title = styled.div`
   color: white;
-  -webkit-backdrop-filter: blur(10px);
-  border-top-right-radius: 3px;
-  border-bottom-right-radius: 3px;
+  padding-left: 1rem;
+  padding-top: 1rem;
+  font-size: 1.25rem;
+  font-weight: bold;
+  text-align: left;
+  text-transform: uppercase;
+`;
 
-  z-index: 0;
-  cursor: default;
+const Description = styled.div`
+  display: block;
+
+  color: white;
+  padding-top: 1rem;
+  padding-left: 1rem;
+  font-size: 0.8rem;
+  text-align: left;
+
+  &::before {
+    opacity: 0.9;
+    color: white;
+  }
 `;
 
 const Sponsor = styled.div`
   display: block;
+  padding-left: 1rem;
 
   color: ${accentColor};
   font-size: 0.8rem;
   text-align: left;
+  text-transform: uppercase;
 
   &::before {
     content: "by ";
@@ -72,13 +101,12 @@ export const Track = ({
   return (
     <div>
       <ImageContainer style={{ backgroundImage: `url(${url})` }}>
-        <Title>
-          {title}
+        <TitleContainer>
+          <Title>{title}</Title>
           <Sponsor>{sponsor}</Sponsor>
-        </Title>
+          <Description>{description}</Description>
+        </TitleContainer>
       </ImageContainer>
-
-      {description}
     </div>
   );
 };


### PR DESCRIPTION
Made it so that the track description shows up when hovering over the image of the respective track. Only downside I've been unable to fix: The card that contains the description closes completely - instead of sliding down - when not 100% extended.

This feature is also fully compatible with mobile, however shows the same flaw that has been described above.