### PR TITLE
fixed: label on image not clickable

### DIFF
--- a/src/routes/landing/Tracks.svelte
+++ b/src/routes/landing/Tracks.svelte
@@ -68,6 +68,7 @@
 					/>
 				</a>
 				<div
+					style="pointer-events: none"
 					class="absolute text-3xl text-white top-36 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-hackaburg-900 p-4  bg-opacity-50 "
 				>
 					{image.alt}


### PR DESCRIPTION
Fixed the following issue reported by @xam-ps

https://user-images.githubusercontent.com/55558407/224512878-fa10ceb2-9a3c-4efb-90e6-446ff535bad7.mp4

